### PR TITLE
feat(security): add server-level security hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.71.1",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.4.0",
+    "tailwind-merge": "^3.4.1",
     "tailwindcss": "^4.1.18",
     "zod": "^4.3.6",
     "zod-openapi": "^5.4.6"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.25.0",
-    "@cloudflare/workers-types": "^4.20260213.0",
+    "@cloudflare/workers-types": "^4.20260214.0",
     "@types/node": "^25.2.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
-        specifier: ^3.4.0
-        version: 3.4.0
+        specifier: ^3.4.1
+        version: 3.4.1
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -83,10 +83,10 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.25.0
-        version: 1.25.0(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(workerd@1.20260212.0)(wrangler@4.65.0(@cloudflare/workers-types@4.20260213.0))
+        version: 1.25.0(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(workerd@1.20260212.0)(wrangler@4.65.0(@cloudflare/workers-types@4.20260214.0))
       '@cloudflare/workers-types':
-        specifier: ^4.20260213.0
-        version: 4.20260213.0
+        specifier: ^4.20260214.0
+        version: 4.20260214.0
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -116,7 +116,7 @@ importers:
         version: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
       wrangler:
         specifier: ^4.65.0
-        version: 4.65.0(@cloudflare/workers-types@4.20260213.0)
+        version: 4.65.0(@cloudflare/workers-types@4.20260214.0)
 
 packages:
 
@@ -298,8 +298,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260213.0':
-    resolution: {integrity: sha512-dr905ft/1R0mnfdT9aun4vanLgIBN27ZyPxTCENKmhctSz6zNmBOvHbzDWAhGE0RBAKFf3X7ifMRcd0MkmBvgA==}
+  '@cloudflare/workers-types@4.20260214.0':
+    resolution: {integrity: sha512-qb8rgbAdJR4BAPXolXhFL/wuGtecHLh1veOyZ1mK6QqWuCdI3vK1biKC0i3lzmzdLR/DZvsN3mNtpUE8zpWGEg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2376,8 +2376,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tailwind-merge@3.4.0:
-    resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
+  tailwind-merge@3.4.1:
+    resolution: {integrity: sha512-2OA0rFqWOkITEAOFWSBSApYkDeH9t2B3XSJuI4YztKBzK3mX0737A2qtxDZ7xkw9Zfh0bWl+r34sF3HXV+Ig7Q==}
 
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
@@ -2768,13 +2768,13 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260212.0
 
-  '@cloudflare/vite-plugin@1.25.0(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(workerd@1.20260212.0)(wrangler@4.65.0(@cloudflare/workers-types@4.20260213.0))':
+  '@cloudflare/vite-plugin@1.25.0(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2))(workerd@1.20260212.0)(wrangler@4.65.0(@cloudflare/workers-types@4.20260214.0))':
     dependencies:
       '@cloudflare/unenv-preset': 2.12.1(unenv@2.0.0-rc.24)(workerd@1.20260212.0)
       miniflare: 4.20260212.0
       unenv: 2.0.0-rc.24
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)
-      wrangler: 4.65.0(@cloudflare/workers-types@4.20260213.0)
+      wrangler: 4.65.0(@cloudflare/workers-types@4.20260214.0)
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -2796,7 +2796,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260212.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20260213.0': {}
+  '@cloudflare/workers-types@4.20260214.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -4639,7 +4639,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwind-merge@3.4.0: {}
+  tailwind-merge@3.4.1: {}
 
   tailwindcss@4.1.18: {}
 
@@ -4771,7 +4771,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260212.0
       '@cloudflare/workerd-windows-64': 1.20260212.0
 
-  wrangler@4.65.0(@cloudflare/workers-types@4.20260213.0):
+  wrangler@4.65.0(@cloudflare/workers-types@4.20260214.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@cloudflare/unenv-preset': 2.12.1(unenv@2.0.0-rc.24)(workerd@1.20260212.0)
@@ -4782,7 +4782,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260212.0
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260213.0
+      '@cloudflare/workers-types': 4.20260214.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,9 +9,10 @@ export function cn(...inputs: ClassValue[]) {
 export const generateId = (length: number = 16): string => {
   const chars =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const bytes = crypto.getRandomValues(new Uint8Array(length));
   let result = '';
   for (let i = 0; i < length; i++) {
-    result += chars.charAt(Math.floor(Math.random() * chars.length));
+    result += chars.charAt(bytes[i] % chars.length);
   }
   return result;
 };

--- a/test/encrypt-decrypt.test.ts
+++ b/test/encrypt-decrypt.test.ts
@@ -70,7 +70,7 @@ describe('Encrypt/Decrypt API', () => {
       const data: { id: string } = await response.json();
       expect(data).toHaveProperty('id');
       expect(typeof data.id).toBe('string');
-      expect(data.id.length).toBe(8);
+      expect(data.id.length).toBe(32);
 
       // Only one KV write (ciphertext only, no key stored)
       expect(mockKV.put).toHaveBeenCalledTimes(1);
@@ -188,7 +188,7 @@ describe('Encrypt/Decrypt API', () => {
     });
 
     it('should handle long messages', async () => {
-      const originalMessage = 'A'.repeat(10000);
+      const originalMessage = 'A'.repeat(5000);
 
       const encryptResponse = await testApp.request('/api/encrypt', {
         method: 'POST',
@@ -215,7 +215,7 @@ describe('Encrypt/Decrypt API', () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id: 'nonexist',
+          id: 'nonexistent_id_that_does_not_exist',
         }),
       });
 
@@ -281,7 +281,7 @@ describe('Encrypt/Decrypt API', () => {
 
   describe('Edge cases and error handling', () => {
     it('should handle corrupted stored data', async () => {
-      const id = 'corrupt8';
+      const id = 'corrupted_data_id_padded_to_32chr';
 
       await mockKV.put(id, 'corrupted-json');
 


### PR DESCRIPTION
## What

Adds server-level security hardening: secure HTTP headers (CSP, HSTS, permissions policy), CSRF protection, cryptographically secure ID generation, and input size limits.

## Why

- `Math.random()` was used for secret ID generation — predictable and unsuitable for security-sensitive identifiers
- No security headers were set (CSP, HSTS, X-Frame-Options, etc.)
- Wide-open CORS allowed any origin to call the API
- No CSRF protection on POST endpoints
- No message size limit allowed potential KV storage abuse
- 8-character IDs had insufficient entropy for brute-force resistance

## How

- Replaced `Math.random()` with `crypto.getRandomValues()` in `generateId()` for cryptographic randomness
- Added Hono's `secureHeaders` middleware with Content-Security-Policy, Referrer-Policy, HSTS, and Permissions-Policy
- Added Hono's `csrf` middleware to validate Origin headers on unsafe methods
- Removed unnecessary `cors()` middleware (same-origin app doesn't need CORS headers)
- Increased ID length from 8 to 32 characters (~190 bits of entropy)
- Added `.max(5000)` validation on message input

## Changes

- Replace `Math.random()` with `crypto.getRandomValues()` in `src/lib/utils.ts`
- Add `secureHeaders` and `csrf` middleware in `src/index.tsx`
- Remove `cors()` middleware
- Add `.max(5000)` to message schema validation
- Increase `generateId(8)` → `generateId(32)` and update decrypt schema min length
- Update dependency versions (tailwind-merge, @cloudflare/workers-types)

## Testing

- [ ] Unit tests updated for new ID length (32 chars)
- [ ] Unit tests updated for new message size limit (5000 chars)
- [ ] All 28 tests passing
- [ ] Manual testing: encrypt → decrypt flow works end-to-end
- [ ] Verify security headers in browser DevTools