### PR TITLE
Improve TypeScript robustness: remove any types and clean code

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -10,12 +10,22 @@ import {
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
+type SonnerTheme = NonNullable<ToasterProps["theme"]>
+
+const SONNER_THEMES: readonly SonnerTheme[] = ["light", "dark", "system"] as const
+
+function toSonnerTheme(theme: string): SonnerTheme {
+  return (SONNER_THEMES as readonly string[]).includes(theme)
+    ? (theme as SonnerTheme)
+    : "system"
+}
+
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={toSonnerTheme(theme)}
       className="toaster group"
       icons={{
         success: <IconCircleCheck className="size-4" />,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import type { Handler } from 'hono';
 import { renderer } from '@/renderer';
 import { secureHeaders } from 'hono/secure-headers';
 import { csrf } from 'hono/csrf';
@@ -13,7 +14,7 @@ app.use('*', secureHeaders());
 app.use('*', csrf());
 app.use(renderer);
 
-const renderShell = (c: any) => {
+const renderShell: Handler<DoldApp> = (c) => {
   return c.render(<div id="root"></div>, {
     title: titleTemplate('Home'),
     description: 'Welcome to Dold, your secure message encryption service.',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@ import { APP_NAME } from '@/constants';
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
 
@@ -28,23 +28,23 @@ export const arrayBufferToBase64 = (buffer: ArrayBuffer): string => {
 };
 
 export const base64ToArrayBuffer = (base64: string): ArrayBuffer => {
-  const binary_string = atob(base64);
-  const len = binary_string.length;
+  const binaryString = atob(base64);
+  const len = binaryString.length;
   const bytes = new Uint8Array(len);
   for (let i = 0; i < len; i++) {
-    bytes[i] = binary_string.charCodeAt(i);
+    bytes[i] = binaryString.charCodeAt(i);
   }
   return bytes.buffer;
 };
 
-export const base64UrlEncode = (str: string) => {
+export const base64UrlEncode = (str: string): string => {
   return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 };
 
-export const base64UrlDecode = (base64str: string) => {
+export const base64UrlDecode = (base64str: string): string => {
   return atob(base64str.replace(/-/g, '+').replace(/_/g, '/'));
 };
 
-export const titleTemplate = (title: string) => {
+export const titleTemplate = (title: string): string => {
   return title ? `${title} | ${APP_NAME}` : APP_NAME;
 };

--- a/src/routes/decrypt.ts
+++ b/src/routes/decrypt.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { decryptMessage, importKey } from '@/lib/crypto';
 import { decryptSchema } from '@/lib/schemas';
-import type { DoldApp } from '@/types';
+import type { DoldApp, StoredCiphertext, StoredKey } from '@/types';
 
 const app = new Hono<DoldApp>();
 
@@ -19,8 +19,8 @@ app.post('/', zValidator('json', decryptSchema), async (c) => {
       return c.json({ error: 'Secret not found or has expired' }, 404);
     }
 
-    const { encrypted, iv } = JSON.parse(ciphertext);
-    const { key } = JSON.parse(keyData);
+    const { encrypted, iv } = JSON.parse(ciphertext) as StoredCiphertext;
+    const { key } = JSON.parse(keyData) as StoredKey;
 
     const cryptoKey = await importKey(key);
     const decryptedMessage = await decryptMessage(cryptoKey, encrypted, iv);

--- a/src/routes/encrypt.ts
+++ b/src/routes/encrypt.ts
@@ -3,7 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import { generateId } from '@/lib/utils';
 import { generateAesKey, encryptMessage, exportKey } from '@/lib/crypto';
 import { encryptSchema } from '@/lib/schemas';
-import type { DoldApp } from '@/types';
+import type { DoldApp, StoredCiphertext, StoredKey } from '@/types';
 
 const app = new Hono<DoldApp>();
 
@@ -17,9 +17,12 @@ app.post('/', zValidator('json', encryptSchema), async (c) => {
 
     const id = generateId(32);
 
+    const stored: StoredCiphertext = { encrypted, iv };
+    const storedKey: StoredKey = { key };
+
     await Promise.all([
-      c.env.DOLD.put(id, JSON.stringify({ encrypted, iv }), { expirationTtl }),
-      c.env.DOLD.put(`doldKey:${id}`, JSON.stringify({ key }), { expirationTtl }),
+      c.env.DOLD.put(id, JSON.stringify(stored), { expirationTtl }),
+      c.env.DOLD.put(`doldKey:${id}`, JSON.stringify(storedKey), { expirationTtl }),
     ]);
 
     return c.json({ id }, 200);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,3 +8,12 @@ export type Meta = {
   title: string;
   description?: string;
 };
+
+export type StoredCiphertext = {
+  encrypted: string;
+  iv: string;
+};
+
+export type StoredKey = {
+  key: JsonWebKey;
+};

--- a/test/encrypt-decrypt.test.ts
+++ b/test/encrypt-decrypt.test.ts
@@ -43,7 +43,7 @@ const mockKV = createMockKV();
 const testApp = {
   request: (path: string, init?: RequestInit) => {
     const req = new Request(`http://localhost${path}`, init);
-    return app.fetch(req, { DOLD: mockKV as any });
+    return app.fetch(req, { DOLD: mockKV as unknown as KVNamespace });
   },
 };
 


### PR DESCRIPTION
- Add StoredCiphertext and StoredKey types to share shape between
  encrypt and decrypt routes, replacing untyped JSON.parse returns
- Replace `c: any` in renderShell with `Handler<DoldApp>` from hono
- Use explicit typed variables when JSON.stringify-ing in encrypt route
- Remove theme type assertion in sonner.tsx with a proper toSonnerTheme
  helper that narrows string to SonnerTheme safely
- Replace `mockKV as any` in tests with `as unknown as KVNamespace`
- Add explicit return types to all utils functions (cn, base64UrlEncode,
  base64UrlDecode, titleTemplate)
- Rename binary_string to binaryString for consistent camelCase

https://claude.ai/code/session_017QcppD9Ru7yAmprgq4B1mR